### PR TITLE
Fix bugs, add JSDoc, and backfill coverage for public APIs

### DIFF
--- a/src/component.test.tsx
+++ b/src/component.test.tsx
@@ -163,6 +163,28 @@ test('A user able to create a reusable component', async () => {
   });
 });
 
+test('Field onChange throws when called with neither a string name nor a ChangeEvent', () => {
+  const TestFormHook = createTestHook();
+  let captured: ((x: unknown) => void) | undefined;
+
+  const Top = () => (
+    <Field controller={TestFormHook.controller} name="age">
+      {(tool) => {
+        // Capture the overloaded onChange so we can invoke it with an
+        // unexpected argument shape outside of React's render cycle.
+        captured = tool.onChange as unknown as (x: unknown) => void;
+        return <input data-testid="age-input" {...tool} />;
+      }}
+    </Field>
+  );
+  render(<Top />);
+
+  expect(captured).toBeDefined();
+  // A number is neither a string (name path) nor an object with `target`
+  // (ChangeEvent path), so the onChange must fall through to the throw.
+  expect(() => captured?.(42)).toThrow('`handleChange` handles unexpected formed object.');
+});
+
 test('`deps` field could destruct memoization', async () => {
   const TestFormHook = createTestHook();
   // intentional sample to replicate the situation

--- a/src/component.tsx
+++ b/src/component.tsx
@@ -4,6 +4,15 @@ type ControlledComponentProps<State extends StateRestriction, Props> = Props & {
   controller: Controller<State>;
 };
 
+/**
+ * Controller-driven variant of `<Slicer>` for reusable components.
+ *
+ * Functionally identical to `controller.components.Slicer`, but accepts the
+ * `controller` as a prop rather than being bound to a single form instance.
+ * Use this when you want to author a shared component (a date range picker,
+ * a multi-step section, etc.) that works against any form whose state satisfies
+ * its required shape.
+ */
 export function Slicer<State extends StateRestriction, R extends ReadonlyArray<unknown>>(
   props: ControlledComponentProps<State, SliceProps<State, R>>,
 ) {
@@ -12,6 +21,14 @@ export function Slicer<State extends StateRestriction, R extends ReadonlyArray<u
   return <Delegate {...restProps} />;
 }
 
+/**
+ * Controller-driven variant of `<Field>` for reusable components.
+ *
+ * Functionally identical to `controller.components.Field`, but accepts the
+ * `controller` as a prop so it can be rendered against any compatible form.
+ * The `name` prop is still constrained to keys of the controller's state,
+ * preserving end-to-end type safety.
+ */
 export function Field<State extends StateRestriction, Name extends keyof State>(
   props: ControlledComponentProps<State, FieldProps<State, Name>>,
 ) {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -248,3 +248,113 @@ test('User is able to push server side validation', async () => {
   expect(state2.isValid).toBeFalsy();
   expect(state2.errors.age).toEqual('Invalid input');
 });
+
+// ============================================================
+// Bug detection tests
+// ============================================================
+
+test('BUG: pushFormErrors should set isValid to true when no actual errors exist', async () => {
+  const TestFormHook = createTestHook();
+
+  const Top = () => {
+    return (
+      <div>
+        <AgeInputComponent controller={TestFormHook.controller} />
+      </div>
+    );
+  };
+
+  render(<Top />);
+
+  // Set valid values for all fields
+  TestFormHook.actions.handleBulkChange(() => ({
+    name: 'test',
+    description: 'desc',
+    age: '25',
+    marked: true,
+  }));
+
+  // Confirm form is valid before pushFormErrors
+  const stateBefore = TestFormHook.api.getState();
+  expect(stateBefore.isValid).toBe(true);
+
+  // Push empty errors (no actual errors)
+  TestFormHook.actions.pushFormErrors(() => ({}));
+
+  // isValid should still be true since there are no real errors
+  const stateAfter = TestFormHook.api.getState();
+  expect(stateAfter.isValid).toBe(true);
+});
+
+test('BUG: withValidation should keep all field keys in errors object (not drop missing ones)', async () => {
+  const TestFormHook = createTestHook();
+
+  const Top = () => {
+    return (
+      <div>
+        <AgeInputComponent controller={TestFormHook.controller} />
+      </div>
+    );
+  };
+
+  render(<Top />);
+
+  // Type invalid age to trigger a validation error on age only
+  const ageInput: HTMLInputElement = screen.getByTestId('age-input');
+  await userEvent.type(ageInput, 'invalid');
+
+  const state = TestFormHook.api.getState();
+
+  // age should have an error
+  expect(state.errors.age).toBeTruthy();
+
+  // Other fields should have null (not undefined) — they must still exist as keys
+  expect(state.errors.name).toBeNull();
+  expect(state.errors.description).toBeNull();
+  expect(state.errors.marked).toBeNull();
+
+  // All original keys should be present
+  const errorKeys = Object.keys(state.errors).sort();
+  const expectedKeys = ['age', 'description', 'marked', 'name'].sort();
+  expect(errorKeys).toEqual(expectedKeys);
+});
+
+test('BUG: isThennable should not crash when handler returns null or undefined', async () => {
+  const TestFormHook = createTestHook();
+
+  // Handler returns undefined (synchronous, no return value)
+  const handleSubmitTester = TestFormHook.handleSubmit((_e) => (_result) => {
+    // intentionally return undefined
+    return undefined;
+  });
+
+  const Top = () => {
+    return (
+      <div>
+        <AgeInputComponent controller={TestFormHook.controller} />
+        <button
+          type="button"
+          data-testid="submit-button"
+          onClick={async (e) => {
+            // This should not throw even when handler returns undefined
+            await handleSubmitTester(e);
+          }}
+        />
+      </div>
+    );
+  };
+
+  render(<Top />);
+
+  // Type invalid value to trigger the error path where isThennable is called
+  const ageInput: HTMLInputElement = screen.getByTestId('age-input');
+  await userEvent.type(ageInput, 'not-a-number');
+
+  const submitButton = screen.getByTestId('submit-button');
+  // This should not throw TypeError: Cannot read properties of undefined (reading 'then')
+  await userEvent.click(submitButton);
+
+  // If we reach here, isThennable didn't crash
+  const state = TestFormHook.api.getState();
+  expect(state.errors.age).toBeTruthy();
+});

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -2,8 +2,8 @@ import {screen} from '@testing-library/dom';
 import {render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import {act} from 'react';
-import {expect, test} from 'vitest';
+import {act, useState} from 'react';
+import {expect, test, vi} from 'vitest';
 
 import * as zod from 'zod';
 
@@ -317,6 +317,182 @@ test('BUG: withValidation should keep all field keys in errors object (not drop 
   const errorKeys = Object.keys(state.errors).sort();
   const expectedKeys = ['age', 'description', 'marked', 'name'].sort();
   expect(errorKeys).toEqual(expectedKeys);
+});
+
+// ============================================================
+// Coverage tests for otherwise-untested public APIs
+// ============================================================
+
+test('reset() restores initial values, clears errors, and resets isDirty', () => {
+  const TestFormHook = createTestHook();
+
+  TestFormHook.actions.handleBulkChange(() => ({
+    name: 'changed',
+    description: 'also changed',
+    age: '42',
+    marked: true,
+  }));
+  expect(TestFormHook.api.getState().isDirty).toBe(true);
+
+  TestFormHook.actions.reset();
+
+  const state = TestFormHook.api.getState();
+  expect(state.value).toEqual(initialState);
+  expect(state.isDirty).toBe(false);
+  expect(state.isValid).toBe(false);
+  expect(state.errors.name).toBeNull();
+  expect(state.errors.age).toBeNull();
+});
+
+test('handleBulkChange updates multiple fields and validates once', () => {
+  const TestFormHook = createTestHook();
+
+  TestFormHook.actions.handleBulkChange(() => ({
+    name: 'test',
+    description: 'desc',
+    age: '25',
+    marked: true,
+  }));
+
+  const state = TestFormHook.api.getState();
+  expect(state.value.name).toBe('test');
+  expect(state.value.description).toBe('desc');
+  expect(state.value.age).toBe('25');
+  expect(state.value.marked).toBe(true);
+  expect(state.isDirty).toBe(true);
+  expect(state.isValid).toBe(true);
+  // every field entry should be null when the form is fully valid
+  expect(Object.values(state.errors).every((v) => v === null)).toBe(true);
+});
+
+test('handleChange ignores unknown field names and leaves state unchanged', () => {
+  const TestFormHook = createTestHook();
+  const before = TestFormHook.api.getState();
+
+  // Cast to bypass the compile-time name constraint — simulating a runtime
+  // slip such as a dynamic field name coming from outside the type system.
+  (TestFormHook.actions.handleChange as (name: string, value: unknown) => void)('doesNotExist', 'anything');
+
+  const after = TestFormHook.api.getState();
+  expect(after).toBe(before);
+});
+
+test('useInitialize seeds the form on mount', () => {
+  const TestFormHook = createTestHook();
+
+  function App() {
+    TestFormHook.useInitialize({name: 'onMount', age: '10'});
+    return <div data-testid="mounted" />;
+  }
+
+  render(<App />);
+
+  const state = TestFormHook.api.getState();
+  expect(state.value.name).toBe('onMount');
+  expect(state.value.age).toBe('10');
+  // unspecified fields keep their original initial
+  expect(state.value.description).toBe('');
+  expect(state.value.marked).toBe(false);
+});
+
+test('useInitialize does not re-run on subsequent renders', async () => {
+  const TestFormHook = createTestHook();
+
+  function App() {
+    const [tick, setTick] = useState(0);
+    // argument is intentionally a fresh object each render to confirm the
+    // effect still does not re-fire (deps are [])
+    TestFormHook.useInitialize({name: 'onMount'});
+    return (
+      <button type="button" data-testid="rerender" onClick={() => setTick(tick + 1)}>
+        {tick}
+      </button>
+    );
+  }
+
+  render(<App />);
+  expect(TestFormHook.api.getState().value.name).toBe('onMount');
+
+  // mutate state after the initialize effect has already fired
+  TestFormHook.actions.handleChange('name', 'changedByUser');
+  expect(TestFormHook.api.getState().value.name).toBe('changedByUser');
+
+  // force a re-render; initialize must not clobber the user's input
+  await userEvent.click(screen.getByTestId('rerender'));
+  expect(TestFormHook.api.getState().value.name).toBe('changedByUser');
+});
+
+test('initializeForm merges partial values into the existing state', () => {
+  const TestFormHook = createTestHook();
+
+  // Seed one field first so we can verify a later partial call preserves it.
+  TestFormHook.actions.initializeForm({description: 'preserved'});
+  TestFormHook.actions.initializeForm({name: 'Alice', age: '30'});
+
+  const state = TestFormHook.api.getState();
+  expect(state.value.name).toBe('Alice');
+  expect(state.value.age).toBe('30');
+  expect(state.value.description).toBe('preserved');
+  expect(state.value.marked).toBe(false);
+});
+
+test('handleSubmit supports a synchronous handler on the success path', async () => {
+  const TestFormHook = createTestHook();
+
+  const handler = vi.fn((_e: unknown) => (_result: unknown) => 'sync-success');
+  const submit = TestFormHook.handleSubmit(handler);
+
+  TestFormHook.actions.handleBulkChange(() => ({
+    name: 'a',
+    description: 'b',
+    age: '5',
+    marked: true,
+  }));
+
+  const result = await submit({} as never);
+  expect(result).toBe('sync-success');
+  expect(handler).toHaveBeenCalledTimes(1);
+});
+
+test('handleSubmit supports a synchronous handler on the failure path', async () => {
+  const TestFormHook = createTestHook();
+
+  const innerCallback = vi.fn((result: {success: boolean}) => {
+    expect(result.success).toBe(false);
+    return 'sync-failure';
+  });
+  const outerCallback = vi.fn((_e: unknown) => innerCallback);
+  const submit = TestFormHook.handleSubmit(outerCallback);
+
+  // initial state has age='' which fails the zod refine → schema fails
+  const result = await submit({} as never);
+  expect(result).toBe('sync-failure');
+  expect(outerCallback).toHaveBeenCalledTimes(1);
+  expect(innerCallback).toHaveBeenCalledTimes(1);
+
+  // failure issues should also be pushed into form errors
+  const state = TestFormHook.api.getState();
+  expect(state.isValid).toBe(false);
+  expect(state.errors.age).toBeTruthy();
+});
+
+test('validation errors map to their respective fields when multiple fail at once', () => {
+  const TestFormHook = createTestHook();
+
+  TestFormHook.actions.handleBulkChange(() => ({
+    // `name` and `marked` both violate the schema; `description` stays valid
+    name: 123 as unknown as string,
+    description: 'ok',
+    age: 'notANumber',
+    marked: 'notBool' as unknown as boolean,
+  }));
+
+  const state = TestFormHook.api.getState();
+  expect(state.isValid).toBe(false);
+  expect(state.errors.name).toBeTruthy();
+  expect(state.errors.marked).toBeTruthy();
+  expect(state.errors.age).toBeTruthy();
+  expect(state.errors.description).toBeNull();
 });
 
 test('BUG: isThennable should not crash when handler returns null or undefined', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,12 @@ import type {ZodIssue, ZodType, infer as zodInfer} from 'zod';
 
 import {isChangeEvent, isThennable} from './utils';
 
+/**
+ * Base constraint for any form state shape handled by Mayoiga.
+ *
+ * State is expected to be a flat (shallow) record. Nested objects are not traversed
+ * by the built-in change/validation machinery.
+ */
 export type StateRestriction = Record<string, unknown>;
 
 type FormStatus = {
@@ -17,13 +23,41 @@ type FormErrors<State extends StateRestriction> = {
   [k in keyof State]: string | null;
 };
 
+/**
+ * Complete snapshot of a form: the current values, per-field error messages,
+ * and top-level status flags.
+ *
+ * @typeParam State - the pre-validation shape of the form
+ */
 export type FullFormState<State extends StateRestriction> = FormStatus & {
   value: State;
   errors: FormErrors<State>;
 };
 
+/**
+ * Signature of the handler used to update a single field value.
+ *
+ * `Name` is constrained to keys of the state so the value type is inferred
+ * from the field being written — invalid field/value pairs fail to type-check.
+ *
+ * @typeParam State - pre-validation form state
+ * @typeParam R - return type of the handler (defaults to `void`; internal
+ *   reducer variants return the next form state)
+ */
 export type HandleChangeAction<State extends StateRestriction, R = void> = <Name extends keyof State>(name: Name, value: State[Name]) => R;
 
+/**
+ * Props for the `<Field>` render-prop component.
+ *
+ * The `children` callback is called with a pre-wired `tool` object (so most inputs
+ * can simply spread it: `<input {...tool} />`), the current value, and the current
+ * error message for the field. `onChange` is overloaded to accept either a
+ * DOM `ChangeEvent` or an explicit `(name, value)` pair — the latter is useful
+ * for non-DOM inputs or typed values that do not serialize to strings.
+ *
+ * @typeParam State - pre-validation form state
+ * @typeParam Name - the key of the field being rendered
+ */
 export type FieldProps<State extends StateRestriction, Name extends keyof State> = {
   name: Name;
   children: (
@@ -44,6 +78,16 @@ export type FieldProps<State extends StateRestriction, Name extends keyof State>
   deps?: ReadonlyArray<unknown>;
 };
 
+/**
+ * Props for the `<Slicer>` render-prop component.
+ *
+ * Unlike `<Field>`, `<Slicer>` subscribes to an arbitrary derivation of the form
+ * state (via `selector`) and only re-renders when the selected tuple changes.
+ * Use this when you need to project multiple fields or computed values at once.
+ *
+ * @typeParam State - pre-validation form state
+ * @typeParam Selected - tuple of values returned by the selector
+ */
 export type SliceProps<State extends StateRestriction, Selected extends ReadonlyArray<unknown>> = {
   selector: (s: FullFormState<State>) => Selected;
   children: (
@@ -253,7 +297,14 @@ function createFormStore<StateBeforeValidation extends StateRestriction, Schema 
   });
 }
 
+/**
+ * The subset of store actions that are safe to call from application code.
+ *
+ * Internal reducers are hidden behind this narrower type so consumers only see
+ * effects (returning `void`) rather than the underlying reducer functions.
+ */
 type ActionsCanBePublic<State extends StateRestriction> = {
+  /** Reset the form back to its original initial state and clear all errors. */
   reset: VoidFunction;
 
   /**
@@ -268,17 +319,46 @@ type ActionsCanBePublic<State extends StateRestriction> = {
       cleanup?: true;
     },
   ) => void;
+  /**
+   * Merge external errors (e.g. server-side validation results) into the form.
+   *
+   * The validator receives the current value and returns a partial error map;
+   * unspecified fields keep their existing error. `isValid` is recomputed from
+   * the merged result.
+   */
   pushFormErrors: (validator: (state: State) => Partial<FormErrors<State>>) => void;
+  /** Update a single field. Triggers schema validation on the next state. */
   handleChange: HandleChangeAction<State>;
+  /**
+   * Update multiple fields in one commit.
+   *
+   * The setter receives the current value and returns a partial patch that is
+   * merged shallowly before validation runs once over the result.
+   */
   handleBulkChange: (setter: (prev: State) => Partial<State>) => void;
 };
 
 /**
- * Restricted type interface of the form store
+ * Narrowed public view of a form store.
+ *
+ * Passing a `Controller` (rather than the full form hook) to reusable components
+ * is the recommended way to keep them decoupled from the concrete form instance.
+ * See `useFormSlice` and the `<Field>` / `<Slicer>` components in `./component`
+ * for consumers of this shape.
+ *
  * TODO: more restriction
  */
 export type Controller<State extends StateRestriction> = {
+  /**
+   * Effect hook that seeds the form with `initialValue` on mount.
+   * Intended to be called once per form instance at the top of a component.
+   */
   useInitialize: (initialValue: Partial<State>) => void;
+  /**
+   * Subscribe to a derived slice of form state. The component re-renders only
+   * when the selected value changes according to `isEqual` (defaults to
+   * reference equality, as provided by the underlying store).
+   */
   useSelector: <R>(selector: (state: FullFormState<State>) => R, isEqual?: (prev: R, current: R) => boolean) => R;
 
   actions: ActionsCanBePublic<State>;
@@ -288,10 +368,30 @@ export type Controller<State extends StateRestriction> = {
   };
 };
 
+/**
+ * The full return value of {@link createFormHook}.
+ *
+ * Embeds a {@link Controller} for sharing with child components, plus the
+ * top-level `handleSubmit` helper and the raw store `api` for advanced use
+ * cases (e.g. reading state outside React, composing with other stores).
+ *
+ * For convenience the controller members are also spread onto the root, so
+ * `form.useSelector(...)` and `form.controller.useSelector(...)` behave
+ * identically.
+ */
 type FormHook<State extends StateRestriction, Schema extends ZodType<unknown>> = {
   controller: Controller<State>;
 
   /**
+   * Build a submit handler that runs schema validation before invoking
+   * the user-supplied logic.
+   *
+   * The outer callback receives the DOM event so the caller can call
+   * `e.preventDefault()` or inspect it before validation; the inner callback
+   * then receives a discriminated result with either the parsed data (on
+   * success) or the collected Zod issues (on failure). On failure the issues
+   * are also pushed into form errors so fields light up automatically.
+   *
    * @param handler handling logic
    * @returns created handler is always return Promise, because of the schema validation run it asynchronously.
    */
@@ -310,10 +410,36 @@ type FormHook<State extends StateRestriction, Schema extends ZodType<unknown>> =
     ) => R,
   ) => (e: BaseSyntheticEvent) => Promise<R>;
 
+  /**
+   * Low-level handle to the underlying store (from `nozuchi`).
+   *
+   * Exposed for advanced integrations — reading/writing state outside React,
+   * subscribing imperatively, or composing this form with other stores.
+   * Prefer the hook-based API (`useSelector`, `actions`, `components`) for
+   * ordinary component code.
+   */
   api: Subscriber<FullFormState<State>, FormControllerBehavior<State>>;
 } & Controller<State>;
 
 /**
+ * Create a self-contained form instance backed by a Zod schema.
+ *
+ * Mayoiga keeps two distinct state types in mind:
+ *
+ * 1. the **pre-validation** shape (what the UI edits, typically loose — nullable
+ *    fields, string inputs for numbers, etc.), inferred from `initialState`.
+ * 2. the **post-validation** shape, inferred from `schema` and surfaced through
+ *    `handleSubmit`. Zod transforms (e.g. `z.string().transform(Number)`) apply
+ *    here, so `data` in the submit callback can have a narrower/coerced type
+ *    than the editable state.
+ *
+ * The returned object exposes hooks (`useSelector`, `useInitialize`), actions
+ * (`handleChange`, `reset`, …), render-prop components (`Field`, `Slicer`),
+ * a `handleSubmit` builder, and the raw store `api` for advanced use.
+ *
+ * @param initialState - default values for every field; shape drives the
+ *   pre-validation type inference
+ * @param schema - Zod schema used for field-level and submit-time validation
  * @typeParam InitialState should be shallow
  */
 export function createFormHook<StateBeforeValidation extends StateRestriction, Schema extends ZodType<unknown>>(
@@ -433,6 +559,19 @@ export function createFormHook<StateBeforeValidation extends StateRestriction, S
   };
 }
 
+/**
+ * Convenience hook that reads a derived slice of state and returns it alongside
+ * the controller's actions — mirroring the `[state, dispatch]` shape familiar
+ * from `useReducer`.
+ *
+ * Prefer this over calling `useSelector` and pulling `actions` separately when
+ * a component consumes both in the same render.
+ *
+ * @param formController - the controller obtained from {@link createFormHook}
+ *   (or passed down as a prop)
+ * @param selector - projection function from full form state to the needed slice
+ * @returns a tuple of `[slicedValue, actions]`
+ */
 export function useFormSlice<State extends StateRestriction, Sliced>(
   formController: Controller<State>,
   selector: (s: FullFormState<State>) => Sliced,

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,7 +160,7 @@ function createFormStore<StateBeforeValidation extends StateRestriction, Schema 
       }
       buf[shallowPath as StateKeys] = iss.message;
       return buf;
-    }, {} as Err);
+    }, {...initialErrors});
 
     return {
       ...prev,
@@ -196,7 +196,7 @@ function createFormStore<StateBeforeValidation extends StateRestriction, Schema 
         }
         buf[shallowPath as StateKeys] = iss.message;
         return buf;
-      }, {} as Err);
+      }, {...initialErrors});
 
       return {
         ...prev,
@@ -213,7 +213,7 @@ function createFormStore<StateBeforeValidation extends StateRestriction, Schema 
       };
       return {
         ...prev,
-        isValid: Object.keys(allErrors).length === 0,
+        isValid: Object.values(allErrors).every((v) => v == null),
         errors: allErrors,
       };
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,15 +152,18 @@ function createFormStore<StateBeforeValidation extends StateRestriction, Schema 
         errors: initialErrors,
       };
     }
-    const newErrors = result.error.issues.reduce((buf, iss) => {
-      // TODO: should support nested value?
-      const shallowPath = iss.path[0];
-      if (shallowPath === undefined) {
+    const newErrors = result.error.issues.reduce(
+      (buf, iss) => {
+        // TODO: should support nested value?
+        const shallowPath = iss.path[0];
+        if (shallowPath === undefined) {
+          return buf;
+        }
+        buf[shallowPath as StateKeys] = iss.message;
         return buf;
-      }
-      buf[shallowPath as StateKeys] = iss.message;
-      return buf;
-    }, {...initialErrors});
+      },
+      {...initialErrors} as Err,
+    );
 
     return {
       ...prev,
@@ -189,14 +192,17 @@ function createFormStore<StateBeforeValidation extends StateRestriction, Schema 
     }),
     handleIssues: (issues) => (prev) => {
       // FIXME: handle duplication
-      const newErrors = issues.reduce((buf, iss) => {
-        const shallowPath = iss.path[0];
-        if (shallowPath === undefined) {
+      const newErrors = issues.reduce(
+        (buf, iss) => {
+          const shallowPath = iss.path[0];
+          if (shallowPath === undefined) {
+            return buf;
+          }
+          buf[shallowPath as StateKeys] = iss.message;
           return buf;
-        }
-        buf[shallowPath as StateKeys] = iss.message;
-        return buf;
-      }, {...initialErrors});
+        },
+        {...initialErrors} as Err,
+      );
 
       return {
         ...prev,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,5 +10,5 @@ export function isChangeEvent<T extends HTMLInputElement>(x: any): x is ChangeEv
 
 // biome-ignore lint/suspicious/noExplicitAny: "unsafe" type guard
 export function isThennable<T>(x: any): x is Promise<T> {
-  return typeof x.then === 'function';
+  return x != null && typeof x.then === 'function';
 }


### PR DESCRIPTION
## Summary
- Fix two pre-existing bugs in `createFormStore` surfaced by the coverage review (`pushFormErrors` `isValid` logic, dropped error keys from `reduce`) and the `isThennable` crash on `null`/`undefined`, with regression tests (commit 3fdea2c).
- Clear the remaining `check:type` / `check:style` violations by reformatting the `reduce` accumulators and casting the spread of the frozen `initialErrors` back to the mutable `Err` type (commit c027d09).
- Add JSDoc comments in English to every public export in `src/index.ts` and `src/component.tsx` — documents the two-stage (pre/post-validation) state model, the render-prop `tool` object, and when to pick `<Slicer>` over `<Field>` (commit d9dedd4).
- Backfill unit tests for public APIs that had no direct coverage: `reset`, `handleBulkChange`, `useInitialize` (mount + re-render), `initializeForm` with partial values, synchronous `handleSubmit` on both paths, multi-field validation error mapping, `handleChange`'s unknown-key guard, and the `<Field>` `onChange` throw path. Uses `api.getState()` and `vi.fn()` call-count assertions to sidestep the false-positive patterns flagged in the review (commit e1c4d80).

`npm run check-all` is green (type, style, lint, build, 22 tests).

## Test plan
- [x] `npm run check:type`
- [x] `npm run check:style`
- [x] `npm run check:lint`
- [x] `npm run build -- --noEmit`
- [x] `npm test` — 22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)